### PR TITLE
[Issue 11] Blueskyでリンクカードが適切に追加できない

### DIFF
--- a/astro/src/components/Client/intents/PopupPreviewForm.tsx
+++ b/astro/src/components/Client/intents/PopupPreviewForm.tsx
@@ -2,9 +2,9 @@ import { Fragment, Dispatch, SetStateAction, useContext, useEffect, useState } f
 import { type popupContent, type msgInfo } from "../common/types"
 import { Profile_context } from "../common/contexts"
 import ShareButton from "./ShareButton"
-import getOgp from "../../../utils/getOgp"
+import { getOgpV2 } from "../../../utils/getOgp"
 import Tweetbox from "../common/Tweetbox"
-import getMeta, { ogpMeta } from "@/utils/getMeta"
+import { ogpMeta } from "@/utils/getMeta"
 import { readShowTaittsuu } from "@/utils/localstorage"
 
 export const Component = ({
@@ -24,8 +24,9 @@ export const Component = ({
                     `/api/fetchHTML?url=${popupContent.url}`
                 ).then((text) => text.text()
                 ).catch()
-                const url = getOgp({ content: html })
-                const meta = getMeta({ content: html })
+                const ogp = await getOgpV2(html)
+                const url = ogp.imageUrl
+                const meta = {title: ogp.title, description: ogp.description}
                 setOgpUrl(url)
                 setOgpMeta(meta)
             } catch (error: unknown) {

--- a/astro/src/components/Client/intents/PopupPreviewForm.tsx
+++ b/astro/src/components/Client/intents/PopupPreviewForm.tsx
@@ -21,7 +21,7 @@ export const Component = ({
         if (popupContent.url !== null) {
             try {
                 let html = await fetch(
-                    popupContent.url
+                    `/api/fetchHTML?url=${popupContent.url}`
                 ).then((text) => text.text()
                 ).catch()
                 const url = getOgp({ content: html })

--- a/astro/src/pages/api/fetchBlob.ts
+++ b/astro/src/pages/api/fetchBlob.ts
@@ -1,15 +1,15 @@
 import type { APIContext, APIRoute } from "astro";
 
 export const GET: APIRoute = async (req: APIContext) => {
-  const url = req.url.searchParams.get("url");
-  if (!url) {
-    return new Response("Missing URL parameter", { status: 400 });
-  }
-  try {
-    const blob = await fetch(url).then((res) => res.blob());
-    const res = new Response(blob);
-    return res;
-  } catch (error) {
-    return new Response("Error fetching Blob", { status: 500 });
-  }
+    const url = req.url.searchParams.get("url");
+    if (!url) {
+        return new Response("Missing URL parameter", { status: 400 });
+    }
+    try {
+        const blob = await fetch(url).then((res) => res.blob());
+        const res = new Response(blob);
+        return res;
+    } catch (error) {
+        return new Response("Error fetching Blob", { status: 500 });
+    }
 };

--- a/astro/src/pages/api/fetchBlob.ts
+++ b/astro/src/pages/api/fetchBlob.ts
@@ -10,6 +10,6 @@ export const GET: APIRoute = async (req: APIContext) => {
     const res = new Response(blob);
     return res;
   } catch (error) {
-    return new Response("Error fetching HTML", { status: 500 });
+    return new Response("Error fetching Blob", { status: 500 });
   }
 };

--- a/astro/src/pages/api/fetchBlob.ts
+++ b/astro/src/pages/api/fetchBlob.ts
@@ -1,0 +1,15 @@
+import type { APIContext, APIRoute } from "astro";
+
+export const GET: APIRoute = async (req: APIContext) => {
+  const url = req.url.searchParams.get("url");
+  if (!url) {
+    return new Response("Missing URL parameter", { status: 400 });
+  }
+  try {
+    const blob = await fetch(url).then((res) => res.blob());
+    const res = new Response(blob);
+    return res;
+  } catch (error) {
+    return new Response("Error fetching HTML", { status: 500 });
+  }
+};

--- a/astro/src/pages/api/fetchHTML.ts
+++ b/astro/src/pages/api/fetchHTML.ts
@@ -1,15 +1,16 @@
 import type { APIContext, APIRoute } from "astro";
 
 export const GET: APIRoute = async (req: APIContext) => {
-  const url = req.url.searchParams.get("url");
-  if (!url) {
-    return new Response("Missing URL parameter", { status: 400 });
-  }
-  try {
-    const html = await fetch(url).then((res) => res.text());
-    const res = new Response(html);
-    return res;
-  } catch (error) {
-    return new Response("Error fetching HTML", { status: 500 });
-  }
+    const url = req.url.searchParams.get("url");
+    if (!url) {
+        return new Response("Missing URL parameter", { status: 400 });
+    }
+    try {
+        const html = await fetch(url).then((res) => res.text());
+
+        const res = new Response(html);
+        return res;
+    } catch (error) {
+        return new Response("Error fetching HTML", { status: 500 });
+    }
 };

--- a/astro/src/pages/api/fetchHTML.ts
+++ b/astro/src/pages/api/fetchHTML.ts
@@ -1,6 +1,14 @@
 import type { APIContext, APIRoute } from "astro";
 
-export const GET: APIRoute = async (req: APIContext) => {
+const extractHead = (html: string): string[] => {
+    // TODO 正規表現が悪用される可能性があるため、より良い実装方法があれば置き換える。
+    // NOTE 特殊文字'>'を含むmetaタグには対応していない。
+    const regex = /<meta\s+[^>]+>/gi;
+    const matchIter: IterableIterator<RegExpMatchArray> = html.matchAll(regex);
+    return Array.from(matchIter, match => match[0]) || [];
+};
+
+export const GET: APIRoute = async (req: APIContext): Promise<Response> => {
     const url = req.url.searchParams.get("url");
     if (!url) {
         return new Response("Missing URL parameter", { status: 400 });
@@ -8,7 +16,12 @@ export const GET: APIRoute = async (req: APIContext) => {
     try {
         const html = await fetch(url).then((res) => res.text());
 
-        const res = new Response(html);
+        // 🚧NOTE: APIサーバーの負荷とセキュリティリスクを考慮して、metaタグを正規表現で抽出する単純な処理を追加している。
+        // TODO: 軽量なHTML解析ライブラリや、より良い実装方法があれば置き換えた方が良い。
+        //       というよりBluesky組み込みのOGP取得APIが公開されていればそちらを使いたい。
+        const meta:string [] = extractHead(html);
+
+        const res = new Response(meta.join("\n"));
         return res;
     } catch (error) {
         return new Response("Error fetching HTML", { status: 500 });

--- a/astro/src/pages/api/fetchHTML.ts
+++ b/astro/src/pages/api/fetchHTML.ts
@@ -1,0 +1,15 @@
+import type { APIContext, APIRoute } from "astro";
+
+export const GET: APIRoute = async (req: APIContext) => {
+  const url = req.url.searchParams.get("url");
+  if (!url) {
+    return new Response("Missing URL parameter", { status: 400 });
+  }
+  try {
+    const html = await fetch(url).then((res) => res.text());
+    const res = new Response(html);
+    return res;
+  } catch (error) {
+    return new Response("Error fetching Blob", { status: 500 });
+  }
+};

--- a/astro/src/pages/api/fetchHTML.ts
+++ b/astro/src/pages/api/fetchHTML.ts
@@ -10,6 +10,6 @@ export const GET: APIRoute = async (req: APIContext) => {
     const res = new Response(html);
     return res;
   } catch (error) {
-    return new Response("Error fetching Blob", { status: 500 });
+    return new Response("Error fetching HTML", { status: 500 });
   }
 };

--- a/astro/src/pages/api/fetchHTML.ts
+++ b/astro/src/pages/api/fetchHTML.ts
@@ -5,7 +5,7 @@ const extractHead = (html: string): string[] => {
     // NOTE 特殊文字'>'を含むmetaタグには対応していない。
     const regex = /<meta\s+[^>]+>/gi;
     const matchIter: IterableIterator<RegExpMatchArray> = html.matchAll(regex);
-    return Array.from(matchIter, match => match[0]) || [];
+    return Array.from(matchIter, (match) => match[0]) || [];
 };
 
 export const GET: APIRoute = async (req: APIContext): Promise<Response> => {
@@ -19,7 +19,7 @@ export const GET: APIRoute = async (req: APIContext): Promise<Response> => {
         // 🚧NOTE: APIサーバーの負荷とセキュリティリスクを考慮して、metaタグを正規表現で抽出する単純な処理を追加している。
         // TODO: 軽量なHTML解析ライブラリや、より良い実装方法があれば置き換えた方が良い。
         //       というよりBluesky組み込みのOGP取得APIが公開されていればそちらを使いたい。
-        const meta:string [] = extractHead(html);
+        const meta: string[] = extractHead(html);
 
         const res = new Response(meta.join("\n"));
         return res;

--- a/astro/src/utils/getOgp.ts
+++ b/astro/src/utils/getOgp.ts
@@ -56,7 +56,7 @@ export const getOgpV2 = async (
     const title = ogp.title;
     const description = ogp.description;
     const imageUrl = ogp.image;
-    const blob = await fetch(`/api/fetchBlob?url=${ogp.image}`).then((res) =>
+    const blob = await fetch(`/api/fetchBlob?url=${imageUrl}`).then((res) =>
         res.blob()
     );
 

--- a/astro/src/utils/getOgp.ts
+++ b/astro/src/utils/getOgp.ts
@@ -22,3 +22,43 @@ const getOgp = ({
     return ogpUrl
 }
 export default getOgp
+
+export const getOgpV2 = async (
+    htmlStr: string
+): Promise<{
+    title: string;
+    description: string;
+    imageUrl: string;
+    blob: Blob;
+}> => {
+    const dom = new DOMParser().parseFromString(htmlStr, "text/html");
+    const ogp = Array.from(dom.head.children).reduce<{
+        title: string;
+        image: string;
+        description: string;
+    }>(
+        (res, elem) => {
+            const prop = elem.getAttribute("property");
+            const name = elem.getAttribute("name");
+            if (prop === "og:title" || name === "twitter:title") {
+                res.title = elem.getAttribute("content") ?? "";
+            }
+            if (prop === "og:image" || name === "twitter:image") {
+                res.image = elem.getAttribute("content") ?? "";
+            }
+            if (prop === "og:description" || name === "twitter:description") {
+                res.description = elem.getAttribute("content") ?? "";
+            }
+            return res;
+        },
+        { title: "", image: "", description: "" }
+    );
+    const title = ogp.title;
+    const description = ogp.description;
+    const imageUrl = ogp.image;
+    const blob = await fetch(`/api/fetchBlob?url=${ogp.image}`).then((res) =>
+        res.blob()
+    );
+
+    return { title, description, imageUrl, blob };
+};


### PR DESCRIPTION
## developブランチに対するdiffが大きくなってしまっているので、はじめにmainブランチからdevelopブランチへのマージをお願いします。

## 概要
Issue#11 の修正案です

主な変更点は

1. CORS エラーが発生していたため、ポスト内の URL についてはバックエンドのAPIサーバーからアクセスするように変更
2. 特殊文字によるOGP取得精度低下の対策として `DOMParser` を利用した実装案の追加
3. 悪意のあるHTMLが取得された場合の対策として、暫定的にmetaタグのみがバックエンドから返されるような仕様に変更

の３つとなります

## メモ

ざっくりとした対応案となってしまい申し訳ないです
PR内の変更範囲が少し広いので、別々のPRに切り分けて必要なものだけマージする形式でも良いかと思います。

1 については「元々CORSエラーが発生しない実装となっていた」といったケースであれば、単に元の実装にロールバックするだけで問題ないかと思います

今回CORSエラーの対応としては [Next.js で CORS エラーを回避してOGPを取得する](https://zenn.dev/tm35/articles/27be33a239a687)を参考に実装した形です
セキュリティ周りにあまり強い方ではないので、まだ改善の余地があるかなといった感じです

２, ３についてはBluesky側で簡単に利用できるAPIが用意されていれば最良という感じですね
バックエンド側に余裕があれば信頼できるOGP取得用ライブラリなどを導入できれば安全かなと思いました
もちろんCORSエラーを回避する手段があればフロント側のリソースに負担させるのもアリではないでしょうか