### PR TITLE
charsetを読み込んで文字コードを特定・変化するコードを追加

### DIFF
--- a/astro/src/pages/api/getOgpMeta.ts
+++ b/astro/src/pages/api/getOgpMeta.ts
@@ -43,6 +43,26 @@ const extractHead = (html: string): ogpMataData => {
     }
 };
 
+const findEncoding = async (htmlBlob: Blob): Promise<string> => {
+    const text = await htmlBlob.text()
+    const headerRegExp: Array<RegExp> = [
+        /(?: *< *meta +charset=["']?)([^"']*)["']?/i,
+        /(?: *< *meta +http-equiv=["']?content-type["']? +content=["']?[^"']*charset=)([^"']*)["']?/i,
+    ]
+    let charset: string | undefined
+    for (let filter of headerRegExp) {
+        if (charset === undefined) {
+            const regResult = filter.exec(text)
+            if (regResult !== null) {
+                charset = regResult[1]
+            }
+        }
+    }
+    console.log(charset)
+    charset = (typeof charset !== "undefined") ? charset.toLowerCase() : "utf-8" // default
+    return charset
+}
+
 export const GET: APIRoute = async ({ request }: APIContext): Promise<Response> => {
     // 返却するするヘッダ
     const Headers = {
@@ -61,15 +81,19 @@ export const GET: APIRoute = async ({ request }: APIContext): Promise<Response> 
         return validateResult
     }
     const url = decodeURIComponent(validateResult)
+    const decodeAsText = async (arrayBuffer: Blob, encoding: string) => new TextDecoder(encoding).decode(await arrayBuffer.arrayBuffer());
 
     try {
-        const html = await fetch(
+        const htmlBlob = await fetch(
             decodeURIComponent(url)
-        ).then((res) => res.text()).catch((res: Error) => {
+        ).then((res) => res.blob()).catch((res: Error) => {
             let e: Error = new Error(res.message)
             e.name = res.name
             throw e
         })
+        const encoding = await findEncoding(htmlBlob)
+        const html = await decodeAsText(htmlBlob, encoding)
+
         const meta: ogpMataData = extractHead(html);
         const response = new Response(
             JSON.stringify(meta),

--- a/astro/tests/getOgp.test.ts
+++ b/astro/tests/getOgp.test.ts
@@ -18,7 +18,7 @@ describe('getOgp Test', () => {
         )
     }, 10000) // long timeouf)
     // YoutubeはCORSが設定されている例
-    test('True Website youtube test', async () => {
+    test('True Website cors site test', async () => {
         let result: ogpMataData | errorResponse = await getOgpMeta(siteurl, "https://www.youtube.com/watch?v=xitQ_oNTVvE")
         expect(result).toEqual(
             <ogpMataData>{
@@ -30,7 +30,7 @@ describe('getOgp Test', () => {
         )
     }, 100000) // long timeouf)
     // Zennは　twitter:imageが設定されていない例
-    test('True Website nicopedia test', async () => {
+    test('True Website no twitter:image test', async () => {
         let result: ogpMataData | errorResponse = await getOgpMeta(siteurl, "https://zenn.dev")
         expect(result).toEqual(
             <ogpMataData>{
@@ -41,4 +41,17 @@ describe('getOgp Test', () => {
             }
         )
     }, 100000) // long timeouf)
+    // It media はエンコーディングが古い shift-jisのサイト
+    test('True Website shift-jis site test', async () => {
+        let result: ogpMataData | errorResponse = await getOgpMeta(siteurl, "https://www.itmedia.co.jp/news/")
+        expect(result).toEqual(
+            <ogpMataData>{
+                type: "meta",
+                title: "ITmedia NEWS",
+                description: "ITがもたらす変化を敏感に感じ取り、仕事や生活に生かしていこうという企業内個人やネットサービス開発者、ベンチャー経営者をコアターゲットに、IT業界動向やネットサービストレンド、ネット上の話題までカバーするニュースを配信します。",
+                image: `https://image.itmedia.co.jp/images/logo/1200x630_500x500_news.gif`
+            }
+        )
+    }, 100000) // long timeouf)
+
 })


### PR DESCRIPTION
あくまで現在の方針を追従する形の場合に文字コードを変化する場合のコードを作成しました。
issue #14 の方針に同意していただける場合は、以下をマージすればいいかなとおもっています。

以下テストログ（skyshare.ukへのテストは、OGPのバージョン文字列が異なるだけであるため、ignoreとしています。）
`True Website shift-jis site test`テスト通過済み
```ts
>> npm run test ./tests/getOgp.test.ts 

> skyshare@1.1.10 test
> PUBLIC_VERSION=$npm_package_version jest ./tests/getOgp.test.ts

 FAIL  tests/getOgp.test.ts
  getOgp Test
    ✕ True Website test (472 ms)
    ✓ True Website cors site test (742 ms)
    ✓ True Website no twitter:image test (313 ms)
    ✓ True Website shift-jis site test (74 ms)

  ● getOgp Test › True Website test

    expect(received).toEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 1

      Object {
        "description": "Skyshare is a web application helps bluesky users post to both bluesky or x.com.",
    -   "image": "https://skyshare.uk/materials/ogp_main.png?updated=v1.1.10",
    +   "image": "https://skyshare.uk/materials/ogp_main.png?updated=v1.2.1",
        "title": "Skyshare - Share Bluesky to X",
        "type": "meta",
      }

       9 |     test('True Website test', async () => {
      10 |         let result: ogpMataData | errorResponse = await getOgpMeta(siteurl, "https://skyshare.uk")
    > 11 |         expect(result).toEqual(
         |                        ^
      12 |             <ogpMataData>{
      13 |                 type: "meta",
      14 |                 title: "Skyshare - Share Bluesky to X",

      at Object.<anonymous> (tests/getOgp.test.ts:11:24)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 3 passed, 4 total
Snapshots:   0 total
Time:        3.206 s, estimated 4 s
```