### PR TITLE
不審なプロトコル、localhost、IPv4, 6アドレスと思わしき文字列を検出する機能の追加

### DIFF
--- a/astro/src/lib/validateRequest.ts
+++ b/astro/src/lib/validateRequest.ts
@@ -24,11 +24,11 @@ const validateRequestReturnURL = ({
         })
     }
     // SSRF対策
-    if (url.toLowerCase().search(/(localhost|127.0.0.1|[::1]|192.168).*/) > 0) {
-        return createErrResponse({
-            statusCode: 502
-        })
-    }
+    // if (url.toLowerCase().search(/localhost/) > 0) {
+    //     return createErrResponse({
+    //         statusCode: 502
+    //     })
+    // }
     return url
 }
 export default validateRequestReturnURL

--- a/astro/src/lib/validateRequest.ts
+++ b/astro/src/lib/validateRequest.ts
@@ -1,5 +1,15 @@
 import createErrResponse from "./createErrResponse";
 
+const protocol_validation: RegExp = /(dict|file|ftp|gopher|ldap|smtp|telnet|tftp):\/\//
+const loopback_validation: RegExp = /localhost/
+const ipv4_validation: RegExp = /(?:\d{0,3}\.){3}\d{0,3}/
+const ipv6_validation: RegExp = /\[[0-9a-fA-F:]+\]/
+
+/**
+ * デコード済みURLを返します。リクエストに問題がある場合はエラーレスポンスを返します。
+ * @param request リクエスト
+ * @returns デコード済みURL または エラーレスポンス
+ */
 const validateRequestReturnURL = ({
     request
 }: {
@@ -14,21 +24,30 @@ const validateRequestReturnURL = ({
     // GET以外はerror型で返却する
     if (request.method !== "GET") {
         return createErrResponse({
-            statusCode: 405
+            statusCode: 405,
         })
     }
+
     const url = new URL(request.url).searchParams.get("url");
     if (url === null) {
         return createErrResponse({
-            statusCode: 406
+            statusCode: 406,
         })
     }
+
+    const decodedUrl = decodeURIComponent(url)
     // SSRF対策
-    // if (url.toLowerCase().search(/localhost/) > 0) {
-    //     return createErrResponse({
-    //         statusCode: 502
-    //     })
-    // }
-    return url
+    if (
+        protocol_validation.test(decodedUrl) ||
+        loopback_validation.test(decodedUrl) ||
+        ipv4_validation.test(decodedUrl) ||
+        ipv6_validation.test(decodedUrl)
+    ) {
+        return createErrResponse({
+            statusCode: 502,
+        })
+    }
+
+    return decodedUrl
 }
 export default validateRequestReturnURL

--- a/astro/src/pages/api/getOgpBlob.ts
+++ b/astro/src/pages/api/getOgpBlob.ts
@@ -15,6 +15,7 @@ export const GET: APIRoute = async ({ request }: APIContext) => {
     // APIの事前処理実施
     const validateResult: string | Response = validateRequestReturnURL({ request })
 
+    // エラーの場合はエラーレスポンスを返却
     if (typeof validateResult !== "string") {
         for (const [key, value] of Object.entries(corsHeaders)) {
             validateResult.headers.append(key, value)
@@ -22,7 +23,9 @@ export const GET: APIRoute = async ({ request }: APIContext) => {
         validateResult.headers.append("Content-Type", "application/json")
         return validateResult
     }
-    const url = decodeURIComponent(validateResult)
+
+    // 正常な場合はURLとして扱う
+    const url: string = validateResult
     try {
         const blob: Blob = await fetch(url).then((res) => res.blob());
         const response: Response = new Response(blob, {

--- a/astro/src/pages/api/getOgpMeta.ts
+++ b/astro/src/pages/api/getOgpMeta.ts
@@ -73,6 +73,7 @@ export const GET: APIRoute = async ({ request }: APIContext): Promise<Response> 
     // APIの事前処理実施
     const validateResult = validateRequestReturnURL({ request })
 
+    // エラーの場合はエラーレスポンスを返却
     if (typeof validateResult !== "string") {
         for (const [key, value] of Object.entries(headers)) {
             validateResult.headers.append(key, value)
@@ -80,7 +81,8 @@ export const GET: APIRoute = async ({ request }: APIContext): Promise<Response> 
         return validateResult
     }
 
-    const url: string = decodeURIComponent(validateResult)
+    // 正常な場合はURLとして扱う
+    const url: string = validateResult
     const decodeAsText = async (arrayBuffer: Blob, encoding: string) => new TextDecoder(encoding).decode(await arrayBuffer.arrayBuffer());
 
     try {


### PR DESCRIPTION
`validateRequest.ts`に

- `dict`, `file`などの不審なプロトコル名と`://`の組み合わせ
- localhostという単語
- 3つの`.`(ピリオド)で数値(0-3桁)を区切る文字列 (IPv4アドレス)
- `[]`で囲われた、16進数と`:`を任意の回数含む文字列 (IPv6アドレス)

を検出する実装を追加しました。

問題なければ feature/issue #11 へマージをお願いします