### PR TITLE
[Issue 16] PCブラウザ向け 投稿ショートカットキーの実装

### DIFF
--- a/astro/package.json
+++ b/astro/package.json
@@ -27,6 +27,7 @@
     "markdown-it": "^14.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-use": "^17.5.0",
     "tailwind-variants": "^0.1.20",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3"

--- a/astro/src/components/Client/bsky/PostForm.tsx
+++ b/astro/src/components/Client/bsky/PostForm.tsx
@@ -1,7 +1,7 @@
 import { memo, useState, useContext, Dispatch, SetStateAction } from "react"
 import { Session_context } from "../common/contexts"
 import { type msgInfo, type modes, type popupContent } from "../common/types"
-import { servicename } from "@/utils/vars";
+import { servicename , pagesPrefix } from "@/utils/vars"
 
 import {
     buildRecordBase,
@@ -17,7 +17,6 @@ import { setSavedTags, readSavedTags } from "@/utils/localstorage";
 
 import { link } from "../common/tailwind_variants";
 
-import { pagesPrefix } from "@/utils/vars";
 import Tweetbox from "../common/Tweetbox"
 import ImgForm from "./ImgForm"
 import ImgViewBox from "./imgctrl/ImgViewBox"
@@ -33,6 +32,9 @@ import LanguageSelect from "./LanguageSelect"
 import Details from "./Details"
 import TagInputList from "./TagInputList"
 import SelfLabelsSelector from "./SelfLabelsSelect"
+
+import { useKey } from "react-use"
+import type { KeyPredicate } from "react-use/lib/useKey"
 
 const siteurl = location.origin
 const MemoImgViewBox = memo(ImgViewBox)
@@ -84,6 +86,10 @@ const Component = ({
     const [appendVia, setAppendVia] = useState<boolean>(false)
 
     const handlePost = async () => {
+        if (!isValidPost()) {
+            return
+        }
+
         const initializePost = () => {
             setPostProcessing(true)
             setProcessing(true)
@@ -265,6 +271,34 @@ const Component = ({
         }
     }
 
+    /**
+     * Ctrl+Enterが押されたかどうかを判定します
+     * @param event イベント
+     * @returns Ctrl+Enterが押された場合true
+     */
+    const isCtrlEnterPressed: KeyPredicate = (event) =>
+        event.ctrlKey === true && event.key === "Enter"
+
+    // Ctrl+Enterが押された場合に投稿する
+    useKey(isCtrlEnterPressed, () => {
+        handlePost().catch((e: unknown) => {
+            const msg: string =
+                e instanceof Error
+                    ? `${e.name}: ${e.message}`
+                    : "Unexpected Error"
+            setMsgInfo({
+                msg: msg,
+                isError: true,
+            })
+        })
+    })
+
+    /**
+     * ポスト可能かどうかを判定します
+     * @returns ポスト可能な場合true
+     */
+    const isValidPost = () => post.length >= 1 || imageFiles.length > 0
+
     return (
         <>
             <Tweetbox>
@@ -272,10 +306,10 @@ const Component = ({
                     <button
                         onClick={handlerCancel}
                         className={link({
-                            enabled: (post.length >= 1 || imageFiles.length > 0),
+                            enabled: isValidPost(),
                             class: ["inline-block", "mx-2", "flex-none"]
                         })}
-                        disabled={!(post.length >= 1 || imageFiles.length > 0)}>
+                        disabled={!isValidPost()}>
                         下書きを消す
                     </button>
                     <div className="flex-1"></div>
@@ -288,7 +322,7 @@ const Component = ({
                             handlePost={handlePost}
                             isProcessing={processing}
                             isPostProcessing={isPostProcessing}
-                            disabled={!(post.length >= 1 || imageFiles.length > 0)} />
+                            disabled={!isValidPost()} />
                     </div>
                 </div>
                 <TextForm


### PR DESCRIPTION
PCブラウザ向けに `Ctrl` + `Enter` キーで投稿する機能を実装しました。

追加で以下のライブラリを導入しています。
- react-use
  - GitHub: https://github.com/streamich/react-use?tab=readme-ov-file
  - ライセンス: Unlicense license